### PR TITLE
Support for custom headers

### DIFF
--- a/SwiftMailer/MandrillTransport.php
+++ b/SwiftMailer/MandrillTransport.php
@@ -359,7 +359,7 @@ class MandrillTransport implements Swift_Transport
                 switch ($header->getFieldName()) {
                     case 'List-Unsubscribe':
                         $headers['List-Unsubscribe'] = $header->getValue();
-						$mandrillMessage['headers'] = $headers;
+                        $mandrillMessage['headers'] = $headers;
                         break;
                     case 'X-MC-InlineCSS':
                         $mandrillMessage['inline_css'] = $header->getValue();
@@ -392,7 +392,7 @@ class MandrillTransport implements Swift_Transport
                     default:
                         if (strncmp($header->getFieldName(), 'X-', 2) === 0) {
                             $headers[$header->getFieldName()] = $header->getValue();
-							$mandrillMessage['headers'] = $headers;
+                            $mandrillMessage['headers'] = $headers;
                         }
                         break;
                 }

--- a/SwiftMailer/MandrillTransport.php
+++ b/SwiftMailer/MandrillTransport.php
@@ -268,7 +268,6 @@ class MandrillTransport implements Swift_Transport
         $images = array();
         $headers = array();
         $tags = array();
-        $inlineCss = null;
 
         foreach ($toAddresses as $toEmail => $toName) {
             $to[] = array(

--- a/Tests/SwiftMailer/MandrillTransportTest.php
+++ b/Tests/SwiftMailer/MandrillTransportTest.php
@@ -128,6 +128,21 @@ class MandrillTransportTest extends \PHPUnit_Framework_TestCase{
         $this->assertMessageSendable($message);
     }
 
+	public function testCustomHeaders()
+	{
+		$transport = $this->createTransport();
+		$message = new \Swift_Message('Test Subject', 'Foo bar');
+		$message
+			->addTo('to@example.com', 'To Name')
+			->addFrom('from@example.com', 'From Name')
+		;
+		$message->getHeaders()->addTextHeader('X-Test-Header', true);
+		$mandrillMessage = $transport->getMandrillMessage($message);
+
+		$this->assertEquals(true, $mandrillMessage['headers']['X-Test-Header']);
+		$this->assertMessageSendable($message);
+	}
+
     public function testSubAccount()
     {
         $transport = $this->createTransport();


### PR DESCRIPTION
Hi,

Now MandrillSwiftMailer doesn't use any other headers than those which support is made. Other headers are just thrown away.

This change supports adding all headers starting with X- to the headers, so that we can add our own custom headers to messages which we can use in development environment to tell for example which was the original recipient before development environment mangled the recipient to the developer itself.

Also we can add custom header which we can use better to track sender of the email if needed from our system.

Did some refactoring to header handling, but implementation can be thought as an example. Main requests is that the all custom X- headers are added to headers.