### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,11 +46,7 @@ Mandrill supports automatic Google Analytics tracking for your links. [docs](htt
 
 An array of string to tag the message with
 
-    $message->getHeaders()->addTextHeader('X-MC-Tags', 'foo,bar');
-    
-or
-
-    $message->getHeaders()->addTextHeader('X-MC-Tags', array('foo','bar'));
+    $message->getHeaders()->addTextHeader('X-MC-Tags', 'foo, bar');
     
 ### Inline CSS
 


### PR DESCRIPTION
Setting headers as array is not possible (anymore). It costs me a lot of time before I got the error message and found out that the array is the problem. Removed it from the README.