### PR TITLE
allow mandrillTransport to pass domain_tracking header through

### DIFF
--- a/SwiftMailer/MandrillTransport.php
+++ b/SwiftMailer/MandrillTransport.php
@@ -335,7 +335,11 @@ class MandrillTransport implements Swift_Transport
             $mandrillMessage['images'] = $images;
         }
 
-        if ($message->getHeaders()->has('X-MC-Autotext')){
+        if ($message->getHeaders()->has('X-MC-TrackingDomain')) {
+            $mandrillMessage['tracking_domain'] = $message->getHeaders()->get('X-MC-TrackingDomain')->getValue();
+        }
+
+        if ($message->getHeaders()->has('X-MC-Autotext')) {
             $autoText = $message->getHeaders()->get('X-MC-Autotext')->getValue();
             if(in_array($autoText, array('true','on','yes','y', true), true)){
                 $mandrillMessage['auto_text'] = true;

--- a/Tests/SwiftMailer/MandrillTransportTest.php
+++ b/Tests/SwiftMailer/MandrillTransportTest.php
@@ -477,4 +477,18 @@ class MandrillTransportTest extends \PHPUnit_Framework_TestCase{
         }
     }
 
+    public function testDomainTrackingHeaders()
+    {
+        $transport = $this->createTransport();
+        $message = new \Swift_Message('Test Subject', 'Foo bar');
+        $message
+            ->addTo('to@example.com', 'To Name')
+            ->addFrom('from@example.com', 'From Name');
+        $message->getHeaders()->addTextHeader('X-MC-TrackingDomain', 'some.custom-domain.com');
+        $mandrillMessage = $transport->getMandrillMessage($message);
+
+        $this->assertEquals('some.custom-domain.com', $mandrillMessage['tracking_domain']);
+        $this->assertMessageSendable($message);
+    }
+
 }


### PR DESCRIPTION
This changes allows us to keep the domain-tracking headers along with the message, this is really usefull for custom tracking domains on Mandrill.

We use it in production environment and seems to work fine !